### PR TITLE
Add GitHub Actions for Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        node: [10.x, 12.x, 14.x]
+
+    name: Node v${{ matrix.node }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+            node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run tests
+        run: yarn test


### PR DESCRIPTION
This PR add a GitHub Actions workflow in order to ensure tests are passing on each push / pull request to this repository.
It is tested against all active [NodeJS versions](https://nodejs.org/en/about/releases/) (10.x, 12.x, 14.x), with Yarn.

An example of this action running can be seen [here](https://github.com/robiiinos/slugify/actions/runs/174649007), and a failing one [here](https://github.com/robiiinos/slugify/actions/runs/174646156).

P.S.1 : Another PR will come to ensure code is linted as well.
P.S.2 : Ensure that the *Actions permissions* setting (which can be found [here](https://github.com/binance-academy/slugify/settings/actions)) is set to " Enable local and third party Actions for this repository".

Feel free to tweak any name or node versions as you wish 🎉 